### PR TITLE
Fix keyboard error in webots-python controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Then just run the following
 Go into the crazyflie_simulation/controllers/ folder and run the following:
 
     swig -python pid_controller.i
-    python setup.py build_ext --inplace
+    python3 setup.py build_ext --inplace
 
 Change controller in crazyflie robot model to crazyflie_controller_py to try it out. 
     

--- a/webots/controllers/crazyflie_controller_py/crazyflie_controller_py.py
+++ b/webots/controllers/crazyflie_controller_py/crazyflie_controller_py.py
@@ -94,13 +94,13 @@ while robot.step(timestep) != -1:
 
     key = Keyboard().getKey()
     while key>0:
-        if key == Keyboard().WB_KEYBOARD_UP:
+        if key == Keyboard.UP:
             pitchDesired += 0.05
-        elif key == Keyboard().WB_KEYBOARD_DOWN:
+        elif key == Keyboard.DOWN:
             pitchDesired -= 0.05
-        elif key == Keyboard().WB_KEYBOARD_RIGHT:
+        elif key == Keyboard.RIGHT:
             rollDesired += 0.05
-        elif key == Keyboard().WB_KEYBOARD_LEFT:
+        elif key == Keyboard.LEFT:
             rollDesired -= 0.05
         else:
             pitchDesired = 0;


### PR DESCRIPTION
Hi :), I'm fairly new to this simulation platform so I may have made a mistake. But, when trying to use the python controller in webots, I got an error message that object Keyboard does not have the attribute WB_KEYBOARD_UP when pressing any key during the simulation. Looking at the python libraries this appears correct, as the fields are named LEFT, RIGHT etc there (webots version R2022a). I've fixed it in this pull request.

Additionally, I had a few issues during installation because my Ubuntu still defaults to python2 instead of 3. I've slightly changed the command in the readme to explicitly use python3. It might be worthwhile to add in the documentation that this may also need to be set in webots (tools->preferences), but I did not include that in this pull request.