### PR TITLE
Fixed README's ignition envi. variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Press play with the simulator and use your keyboard to  control it
 
 3- Put this repo in your ~/.bashrc and source it in your terminal
 
-    export IGN_GAZEBO_RESOURCE_PATH="path/to/crazyflie_simulation/gazebo-ignition/":"path/to/crazyflie_simulation/gazebo-ignition/worlds/"
+    export IGN_GAZEBO_RESOURCE_PATH="path/to/crazyflie-simulation/gazebo-ignition/"
 
 4- Try out the crazyflie world with: 
     ign gazebo crazyflie_world.sdf


### PR DESCRIPTION
This PR fixes issue #23 . In the end, it was a small mistake in the absolute path targeting the crazyflie model. 

I also removed the world path from IGN_GAZEBO_RESOURCE_PATH.