### PR TITLE
Put world time back to default

### DIFF
--- a/webots/worlds/crazyflie_apartement.wbt
+++ b/webots/worlds/crazyflie_apartement.wbt
@@ -41,7 +41,6 @@ WorldInfo {
     "This simulation has the Crazyflie in an apartement with wall following'"
   ]
   title "Crazyflie Apartment"
-  basicTimeStep 16
 }
 Viewpoint {
   orientation -0.2069634151755047 0.17139042951652655 0.9632193236480631 1.794980546924951


### PR DESCRIPTION
We accidentally put in a wrong timestep in there, which is not the same as the bare crazyflie world and screws up the gains. 