### PR TITLE
Gazebo world model, update plugins from ignition to gz

### DIFF
--- a/simulator_files/gazebo/worlds/crazyflie_world.sdf
+++ b/simulator_files/gazebo/worlds/crazyflie_world.sdf
@@ -18,20 +18,21 @@ Copyright (c) 2022 Bitcraze
       <real_time_factor>1.0</real_time_factor>
     </physics>
     <plugin
-      filename="ignition-gazebo-physics-system"
-      name="ignition::gazebo::systems::Physics">
+      filename="gz-sim-physics-system"
+      name="gz::sim::systems::Physics">
     </plugin>
     <plugin
-      filename="ignition-gazebo-user-commands-system"
-      name="ignition::gazebo::systems::UserCommands">
+      filename="gz-sim-user-commands-system"
+      name="gz::sim::systems::UserCommands">
     </plugin>
     <plugin
-      filename="ignition-gazebo-scene-broadcaster-system"
-      name="ignition::gazebo::systems::SceneBroadcaster">
+      filename="gz-sim-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
     </plugin>
     <plugin
-      filename="ignition-gazebo-contact-system"
-      name="ignition::gazebo::systems::Contact">
+      filename="gz-sim-sensors-system"
+      name="gz::sim::systems::Sensors">
+      <render_engine>ogre2</render_engine>
     </plugin>
 
     <light type="directional" name="sun">


### PR DESCRIPTION
Hi!

I've updated the Crazyflie world file for gazebo. The outdated plugins seems to not work anymore in the latest Gazebo Ionic. In Harmonic we are also supposed to use the latest one and these work fine on that version.

Also the contact plugin doesn't seem to be valid for this example, but the sensor one is of course.


